### PR TITLE
[feat] improvements for tools selection in plugins page

### DIFF
--- a/src/app/(app)/settings/code-review/_components/_layout.tsx
+++ b/src/app/(app)/settings/code-review/_components/_layout.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { useParams, usePathname } from "next/navigation";
+import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import {
     Collapsible,
@@ -64,7 +65,11 @@ export const AutomationCodeReviewLayout = ({
     }>();
 
     const mainRoutes = useMemo(() => {
-        const routes = [
+        const routes: Array<{
+            label: string;
+            href: string;
+            badge?: React.ReactNode;
+        }> = [
             {
                 label: "Git Settings",
                 href: "/settings/git",
@@ -73,12 +78,19 @@ export const AutomationCodeReviewLayout = ({
                 label: "Subscription",
                 href: "/settings/subscription",
             },
-        ] satisfies Array<{ label: string; href: string }>;
+        ];
 
         if (pluginsPageFeatureFlag?.value) {
             routes.push({
                 label: "Plugins",
                 href: "/settings/plugins",
+                badge: (
+                    <Badge
+                        variant="secondary"
+                        className="pointer-events-none -my-1 h-6 min-h-auto px-2.5">
+                        Alpha
+                    </Badge>
+                ),
             });
         }
 
@@ -118,6 +130,7 @@ export const AutomationCodeReviewLayout = ({
                                                 decorative
                                                 className="w-full justify-start"
                                                 active={pathname === route.href}
+                                                rightIcon={route.badge}
                                                 variant={
                                                     pathname.startsWith(
                                                         route.href,

--- a/src/app/(app)/settings/plugins/page.tsx
+++ b/src/app/(app)/settings/plugins/page.tsx
@@ -22,7 +22,14 @@ export default async function PluginsPage() {
         <Page.Root>
             <Page.Header>
                 <Page.TitleContainer>
-                    <Page.Title>Plugins</Page.Title>
+                    <div className="flex items-center gap-2">
+                        <Page.Title>Plugins</Page.Title>
+                        <Badge
+                            variant="secondary"
+                            className="pointer-events-none">
+                            Alpha
+                        </Badge>
+                    </div>
 
                     <Page.Description>
                         Connect Kody to external tools and APIs to enhance your
@@ -46,7 +53,7 @@ export default async function PluginsPage() {
                                 size="lg"
                                 decorative
                                 variant="helper"
-                                className="w-full items-start gap-0 px-0 py-0">
+                                className="h-full w-full items-start gap-0 px-0 py-0">
                                 <Card className="flex w-full gap-0 bg-transparent shadow-none">
                                     <CardHeader className="gap-4">
                                         <div className="flex h-fit flex-row items-center gap-5">

--- a/src/core/components/ui/checkbox.tsx
+++ b/src/core/components/ui/checkbox.tsx
@@ -2,16 +2,18 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import type { VariantProps } from "class-variance-authority";
 import { CheckIcon, MinusIcon } from "lucide-react";
 import { cn } from "src/core/utils/components";
 
-import { Button } from "./button";
+import { Button, type buttonVariants } from "./button";
 
 const Checkbox = React.forwardRef<
     React.ComponentRef<typeof CheckboxPrimitive.Root>,
-    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & {
-        decorative?: boolean;
-    }
+    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> &
+        VariantProps<typeof buttonVariants> & {
+            decorative?: boolean;
+        }
 >(({ className, ...props }, ref) => (
     <CheckboxPrimitive.Root
         ref={ref}
@@ -24,7 +26,9 @@ const Checkbox = React.forwardRef<
         )}
         {...props}
         asChild>
-        <Button variant="primary" size="icon-sm">
+        <Button
+            size={props.size ?? "icon-sm"}
+            variant={props.variant ?? "primary"}>
             <CheckboxPrimitive.Indicator>
                 {props.checked === "indeterminate" && <MinusIcon />}
                 {props.checked === true && <CheckIcon />}

--- a/src/core/components/ui/input.tsx
+++ b/src/core/components/ui/input.tsx
@@ -53,7 +53,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref,
     ) => {
         return (
-            <div className="relative">
+            <div className="relative flex-1">
                 {LeftIcon && (
                     <div className="pointer-events-none absolute inset-y-0 left-4 z-1 flex items-center [&_svg]:size-5 [&_svg]:text-current">
                         {LeftIcon}

--- a/src/lib/services/mcp-manager/fetch.ts
+++ b/src/lib/services/mcp-manager/fetch.ts
@@ -56,6 +56,7 @@ export const getMCPPluginTools = ({
             name: string;
             description: string;
             provider: string;
+            warning: boolean;
         }>
     >(`/mcp/${provider}/integrations/${id}/tools`);
 


### PR DESCRIPTION
This pull request introduces several enhancements to the plugins page and related components in the `kodustech/web` repository. Key changes include:

1. **Settings Sidebar**: A new 'Plugins' navigation item is added to the settings sidebar, conditionally displayed based on a feature flag. The route data structure is updated to support an optional badge, labeling the 'Plugins' item as 'Alpha'.

2. **Plugin Installation Modal**: A security confirmation step is added for plugins with tools that have warnings. The UI now includes a confirmation checkbox, and the installation logic ensures users acknowledge the risks. Tools with warnings are not pre-selected by default.

3. **SelectTools Component**: Enhancements include a search filter for tools, a 'Select all'/'Unselect all' feature, and UI indicators for tools with warnings, improving usability for managing numerous tools.

4. **Plugins Page UI**: Minor UI enhancements are made, including an 'Alpha' badge next to the page title and adjustments to plugin card styling for a more uniform grid layout.

5. **Checkbox Component**: The `Checkbox` component is enhanced with `variant` and `size` props from the `Button` component, allowing for greater visual customization.

6. **Input Component**: The `Input` component's styling is modified by adding the `flex-1` utility class, enabling it to expand and fill available space within a flex container.

7. **MCP Plugin Tools**: The type definition for MCP plugin tools is updated to include a new `warning` property, with a suggestion to make it optional to handle cases where the API might not return it, preventing potential runtime issues.