### PR TITLE
Adding team Id

### DIFF
--- a/src/app/(app)/settings/code-review/_components/git-directory-selector.tsx
+++ b/src/app/(app)/settings/code-review/_components/git-directory-selector.tsx
@@ -24,6 +24,7 @@ export const GitDirectorySelector = ({
     const directoryTree = useSuspenseGetRepositoryTree({
         repositoryId,
         organizationId,
+        teamId,
         treeType: "directories",
     });
 

--- a/src/lib/services/codeManagement/hooks.ts
+++ b/src/lib/services/codeManagement/hooks.ts
@@ -45,6 +45,7 @@ export function useGetRepositories(
 export function useSuspenseGetRepositoryTree(params: {
     organizationId: string;
     repositoryId: string;
+    teamId?: string;
     treeType?: "directories" | "files";
 }) {
     return useSuspenseFetch<{ repository: string; tree: GitFileOrFolder[] }>(


### PR DESCRIPTION
This pull request enhances the `useSuspenseGetRepositoryTree` hook by adding an optional `teamId` parameter. This allows the system to fetch repository directory trees with a specific team context. The `GitDirectorySelector` component has been updated to pass the `teamId` when requesting the repository tree, enabling directory selection to be potentially scoped or filtered by team.