### PR TITLE
adding server side search for pr selectbox

### DIFF
--- a/src/core/components/system/select-pull-requests-server-search.tsx
+++ b/src/core/components/system/select-pull-requests-server-search.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@components/ui/command";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@components/ui/popover";
+import { Spinner } from "@components/ui/spinner";
+import { useDebouncedPRSearch } from "@services/codeManagement/hooks/use-debounced-pr-search";
+import { ChevronsUpDown } from "lucide-react";
+
+type PullRequest = {
+    id: string;
+    pull_number: number;
+    repository: string;
+    title: string;
+    url: string;
+};
+
+export const SelectPullRequestWithServerSearch = (props: {
+    id?: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    disabled?: boolean;
+    teamId: string;
+    repositoryId?: string;
+    value?: PullRequest;
+    onChange: (value: PullRequest) => void;
+}) => {
+    const {
+        id = "select-pull-request",
+        open,
+        onOpenChange,
+        disabled,
+        teamId,
+        repositoryId,
+        onChange,
+        value,
+    } = props;
+
+    const {
+        searchInput,
+        setSearchInput,
+        pullRequests,
+        isSearching,
+    } = useDebouncedPRSearch({
+        teamId,
+        repositoryId,
+    });
+
+    console.log("🎨 SelectPullRequestWithServerSearch - Debug:");
+    console.log("  📊 Pull Requests:", pullRequests);
+    console.log("  📏 PR Count:", pullRequests?.length);
+    console.log("  🔍 Search Input:", searchInput);
+    console.log("  ⚡ Is Searching:", isSearching);
+
+    const PRsGroupedByRepository = pullRequests.reduce(
+        (acc, current) => {
+            if (!acc[current.repository]) acc[current.repository] = [];
+            acc[current.repository].push(current);
+            return acc;
+        },
+        {} as Record<string, typeof pullRequests>,
+    );
+
+    console.log("📊 Grouped by Repository:", PRsGroupedByRepository);
+
+    return (
+        <Popover open={open} onOpenChange={onOpenChange}>
+            <PopoverTrigger asChild>
+                <Button
+                    id={id}
+                    type="button"
+                    size="lg"
+                    variant="helper"
+                    disabled={disabled}
+                    className="flex min-h-16 w-full justify-between">
+                    <div className="flex w-full items-center">
+                        {!value ? (
+                            <span className="flex-1">
+                                No pull request selected
+                            </span>
+                        ) : (
+                            <div className="flex-1">
+                                <span className="text-primary-light text-xs">
+                                    {value.repository}
+                                </span>
+
+                                <span className="text-text-secondary line-clamp-1 wrap-anywhere">
+                                    <strong>#{value.pull_number}</strong>{" "}
+                                    {value.title}
+                                </span>
+                            </div>
+                        )}
+                    </div>
+
+                    <ChevronsUpDown className="-mr-2 shrink-0 opacity-50" />
+                </Button>
+            </PopoverTrigger>
+
+            <PopoverContent
+                align="start"
+                className="w-[var(--radix-popover-trigger-width)] p-0">
+                <Command 
+                    className="w-full"
+                    shouldFilter={false} // Disable internal filtering - API handles it
+                >
+                    <CommandInput 
+                        placeholder="Search by title or number (e.g., 'fix bug' or '#123')"
+                        value={searchInput}
+                        onValueChange={setSearchInput}
+                    />
+
+                    <CommandList className="overflow-y-auto">
+                        {isSearching ? (
+                            <div className="flex items-center justify-center p-4">
+                                <Spinner className="mr-2 size-4" />
+                                <span className="text-sm text-muted-foreground">
+                                    Searching...
+                                </span>
+                            </div>
+                        ) : (
+                            <>
+                                <CommandEmpty className="flex h-full items-center justify-center">
+                                    {searchInput.trim() 
+                                        ? "No pull request found with current search query"
+                                        : "Start typing to search pull requests"
+                                    }
+                                </CommandEmpty>
+
+                                <div className="max-h-72">
+                                    {Object.entries(PRsGroupedByRepository).map(
+                                        ([repository, prs]) => (
+                                            <CommandGroup
+                                                heading={repository}
+                                                key={repository}>
+                                                {prs.map((pr) => (
+                                                    <CommandItem
+                                                        key={`${pr.id}_${pr.pull_number}`}
+                                                        value={`${repository}#${pr.pull_number}`}
+                                                        onSelect={() => {
+                                                            onChange(pr);
+                                                            onOpenChange(false);
+                                                        }}
+                                                        className="flex items-center justify-start">
+                                                        <span className="text-text-secondary line-clamp-2">
+                                                            <strong className="mr-2 font-mono">
+                                                                #{pr.pull_number}
+                                                            </strong>
+
+                                                            {pr.title}
+                                                        </span>
+                                                    </CommandItem>
+                                                ))}
+                                            </CommandGroup>
+                                        ),
+                                    )}
+                                </div>
+                            </>
+                        )}
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    );
+};

--- a/src/core/hooks/use-debounce.ts
+++ b/src/core/hooks/use-debounce.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook that debounces a value by a specified delay
+ * @param value - The value to debounce
+ * @param delay - The delay in milliseconds
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+}

--- a/src/core/utils/pr-search.ts
+++ b/src/core/utils/pr-search.ts
@@ -1,0 +1,78 @@
+/**
+ * Utility functions for PR search functionality
+ */
+
+export interface SearchParams {
+    type: 'number' | 'title';
+    value: string;
+}
+
+/**
+ * Detects if the search input is a PR number or title search
+ * @param input - The search input from user
+ * @returns Object with search type and cleaned value
+ */
+export function detectSearchType(input: string): SearchParams {
+    if (!input || input.trim() === '') {
+        return { type: 'title', value: '' };
+    }
+
+    const trimmedInput = input.trim();
+
+    // Check if it's a number (with or without #)
+    const numberPattern = /^#?(\d+)$/;
+    const match = trimmedInput.match(numberPattern);
+
+    if (match) {
+        // It's a number - extract just the digits
+        return {
+            type: 'number',
+            value: match[1] // The captured group without #
+        };
+    }
+
+    // It's a title search
+    return {
+        type: 'title',
+        value: trimmedInput
+    };
+}
+
+/**
+ * Builds search parameters for API call
+ * @param input - The search input from user
+ * @param teamId - Team ID for the search
+ * @param repositoryId - Optional repository ID to filter by
+ * @returns API parameters object
+ */
+export function buildSearchParams(
+    input: string,
+    teamId: string,
+    repositoryId?: string
+): Record<string, unknown> {
+    const searchParams = detectSearchType(input);
+    
+    const params: Record<string, unknown> = {
+        teamId,
+    };
+
+    if (repositoryId && repositoryId !== 'global') {
+        params.repositoryId = repositoryId;
+    }
+
+    if (searchParams.value) {
+        if (searchParams.type === 'number') {
+            params.number = searchParams.value;
+        } else {
+            params.title = searchParams.value;
+        }
+    }
+
+    console.log("🔧 buildSearchParams - Debug:");
+    console.log("  📝 Input:", input);
+    console.log("  🎯 Detected Type:", searchParams.type);
+    console.log("  💎 Detected Value:", searchParams.value);
+    console.log("  📦 Final Params:", params);
+
+    return params;
+}

--- a/src/lib/services/codeManagement/hooks.ts
+++ b/src/lib/services/codeManagement/hooks.ts
@@ -55,15 +55,70 @@ export function useSuspenseGetRepositoryTree(params: {
 }
 
 export function useSuspenseGetOnboardingPullRequests(teamId: string) {
-    return useSuspenseFetch<
+    const rawData = useSuspenseFetch<
         {
             id: string;
             pull_number: number;
-            repository: string;
+            repository: {
+                id: string;
+                name: string;
+            };
             title: string;
             url: string;
         }[]
     >(CODE_MANAGEMENT_API_PATHS.GET_ONBOARDING_PULL_REQUESTS, {
         params: { teamId },
     });
+
+    // Transform to legacy format for compatibility
+    return rawData.map(pr => ({
+        id: pr.id,
+        pull_number: pr.pull_number,
+        repository: pr.repository.name, // Extract name from repository object
+        title: pr.title,
+        url: pr.url
+    }));
 }
+
+export function useSearchPullRequests(
+    teamId: string,
+    searchParams: {
+        number?: string;
+        title?: string;
+        repositoryId?: string;
+    } = {}
+) {
+    console.log("🌐 useSearchPullRequests - Debug:");
+    console.log("  📋 Search Params:", searchParams);
+    console.log("  👥 Team ID:", teamId);
+    console.log("  🌍 URL:", CODE_MANAGEMENT_API_PATHS.GET_ONBOARDING_PULL_REQUESTS);
+    
+    return useFetch<
+        {
+            id: string;
+            pull_number: number;
+            repository: {
+                id: string;
+                name: string;
+            };
+            title: string;
+            url: string;
+        }[]
+    >(
+        CODE_MANAGEMENT_API_PATHS.GET_ONBOARDING_PULL_REQUESTS,
+        {
+            params: {
+                teamId,
+                ...searchParams,
+            },
+        },
+        true, // Always enabled
+        {
+            refetchOnWindowFocus: false,
+            staleTime: 0, // No cache - always fresh data
+            gcTime: 0, // Don't cache results
+        }
+    );
+}
+
+export { useDebouncedPRSearch } from "./hooks/use-debounced-pr-search";

--- a/src/lib/services/codeManagement/hooks/use-debounced-pr-search.ts
+++ b/src/lib/services/codeManagement/hooks/use-debounced-pr-search.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { buildSearchParams } from "src/core/utils/pr-search";
+import { useDebounce } from "@hooks/use-debounce";
+import { useSearchPullRequests, useSuspenseGetOnboardingPullRequests } from "@services/codeManagement/hooks";
+
+type PullRequest = {
+    id: string;
+    pull_number: number;
+    repository: string;
+    title: string;
+    url: string;
+};
+
+interface UseDebouncedPRSearchParams {
+    teamId: string;
+    repositoryId?: string;
+    debounceMs?: number;
+}
+
+interface UseDebouncedPRSearchReturn {
+    searchInput: string;
+    setSearchInput: (input: string) => void;
+    pullRequests: PullRequest[];
+    isSearching: boolean;
+    isLoadingInitial: boolean;
+    error: Error | null;
+}
+
+/**
+ * Hook for searching pull requests with debounce
+ * Falls back to initial load when no search is active
+ */
+export function useDebouncedPRSearch({
+    teamId,
+    repositoryId,
+    debounceMs = 300,
+}: UseDebouncedPRSearchParams): UseDebouncedPRSearchReturn {
+    const [searchInput, setSearchInput] = useState("");
+    const debouncedSearchInput = useDebounce(searchInput, debounceMs);
+
+    // Get search params from debounced input
+    const searchParams = useMemo(() => {
+        if (!debouncedSearchInput.trim()) {
+            return {};
+        }
+
+        return buildSearchParams(debouncedSearchInput, teamId, repositoryId);
+    }, [debouncedSearchInput, teamId, repositoryId]);
+
+    // Always search via API - include empty search to get all results
+    const apiSearchParams = useMemo(() => {
+        const baseParams = {
+            number: searchParams.number as string,
+            title: searchParams.title as string,
+            repositoryId: searchParams.repositoryId as string,
+        };
+
+        // If no search input, send empty title to get all results
+        if (!debouncedSearchInput.trim()) {
+            return {
+                ...baseParams,
+                title: "", // Empty search to get all results
+                number: undefined,
+            };
+        }
+
+        return baseParams;
+    }, [searchParams, debouncedSearchInput]);
+
+    // Always use server-side search
+    const {
+        data: searchResults,
+        isLoading: isSearching,
+        error,
+        refetch,
+    } = useSearchPullRequests(teamId, apiSearchParams);
+
+    // Transform search results to match expected format
+    const transformedSearchResults = useMemo(() => {
+        if (!searchResults || !Array.isArray(searchResults)) return [];
+        
+        return searchResults.map(pr => ({
+            id: pr.id,
+            pull_number: pr.pull_number,
+            repository: pr.repository.name, // Extract name from repository object
+            title: pr.title,
+            url: pr.url
+        }));
+    }, [searchResults]);
+
+    // Always return API results (no fallback to initial data)
+    const pullRequests = useMemo(() => {
+        console.log("🔍 useDebouncedPRSearch - Debug:");
+        console.log("  📝 Search Input:", debouncedSearchInput);
+        console.log("  🔧 API Search Params:", apiSearchParams);
+        console.log("  📡 Raw API Response:", searchResults);
+        console.log("  🔄 Transformed Results:", transformedSearchResults);
+        console.log("  ⚡ Is Searching:", isSearching);
+        if (error) console.log("  ❌ Error:", error);
+
+        console.log("🎯 Always returning API results:", transformedSearchResults);
+        return transformedSearchResults;
+    }, [debouncedSearchInput, apiSearchParams, searchResults, transformedSearchResults, isSearching, error]);
+
+    return {
+        searchInput,
+        setSearchInput,
+        pullRequests,
+        isSearching: Boolean(debouncedSearchInput.trim()) && isSearching,
+        isLoadingInitial: false, // Since we're using suspense for initial load
+        error,
+    };
+}


### PR DESCRIPTION
This pull request implements server-side search for the Pull Request (PR) selection dropdown, specifically within the Code Review settings.

The previous client-side filtering of all pull requests has been replaced with a more performant and scalable approach. This change introduces:
*   **Dynamic PR Search:** Users can now search for pull requests by title or number (e.g., `#123`) directly within the selection dropdown.
*   **Debounced API Calls:** Search queries are debounced to optimize network requests, ensuring a smooth user experience.
*   **Improved Performance & Scalability:** By shifting the filtering and search logic to the server, the client-side processing is significantly reduced, leading to faster load times and better responsiveness, particularly for environments with a large volume of pull requests.
*   **Enhanced User Experience:** Pull requests are fetched and displayed dynamically based on search input, grouped by repository for clear organization.