### PR TITLE
new runondraft code review setting

### DIFF
--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/run-on-draft.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/run-on-draft.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button } from "@components/ui/button";
+import { CardHeader } from "@components/ui/card";
+import { Heading } from "@components/ui/heading";
+import { Switch } from "@components/ui/switch";
+import { Controller, useFormContext } from "react-hook-form";
+
+import type { CodeReviewFormType } from "../../../_types";
+
+export const RunOnDraft = () => {
+    const form = useFormContext<CodeReviewFormType>();
+
+    return (
+        <Controller
+            name="runOnDraft"
+            control={form.control}
+            render={({ field }) => (
+                <Button
+                    size="sm"
+                    variant="helper"
+                    onClick={() => field.onChange(!field.value)}
+                    className="w-full">
+                    <CardHeader className="flex flex-row items-center justify-between gap-6">
+                        <div className="flex flex-col gap-1">
+                            <Heading variant="h3">
+                                Enable Running on Draft Pull Requests
+                            </Heading>
+
+                            <p className="text-text-secondary text-sm">
+                                If enabled, Kody will run automated code reviews
+                                on draft Pull Requests and provide feedback,
+                                even if the Pull Request is not ready for
+                                review.
+                            </p>
+                        </div>
+
+                        <Switch decorative checked={field.value} />
+                    </CardHeader>
+                </Button>
+            )}
+        />
+    );
+};

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
@@ -32,6 +32,7 @@ import { IsRequestChangesActive } from "./_components/is-request-changes-active"
 import { KodusConfigFileOverridesWebPreferences } from "./_components/kodus-config-file-overrides-web-preferences";
 import { LanguageSelector } from "./_components/language-selector";
 import { PullRequestApprovalActive } from "./_components/pull-request-approval-active";
+import { RunOnDraft } from "./_components/run-on-draft";
 
 export default function General() {
     const platformConfig = usePlatformConfig();
@@ -186,6 +187,7 @@ export default function General() {
                 <KodusConfigFileOverridesWebPreferences />
                 <PullRequestApprovalActive />
                 <IsRequestChangesActive />
+                <RunOnDraft />
                 <AnalysisTypes />
                 <IgnorePaths />
                 <IgnoredTitleKeywords />

--- a/src/app/(app)/settings/code-review/_components/generate-rules.tsx
+++ b/src/app/(app)/settings/code-review/_components/generate-rules.tsx
@@ -101,6 +101,7 @@ export const GenerateRulesButton = () => {
                 config?.suggestionControl?.severityLevelFilter ??
                 SeverityLevel.HIGH,
         },
+        runOnDraft: config?.runOnDraft ?? true,
     };
 
     // if more settings are added to this page consider switching to using a form

--- a/src/app/(app)/settings/code-review/_types.ts
+++ b/src/app/(app)/settings/code-review/_types.ts
@@ -100,6 +100,7 @@ export type CodeReviewGlobalConfig = {
     kodusConfigFileOverridesWebPreferences: boolean;
     isRequestChangesActive: boolean;
     kodyRulesGeneratorEnabled?: boolean;
+    runOnDraft: boolean;
 };
 
 type CodeReviewRepositoryConfigBase = CodeReviewGlobalConfig & {

--- a/src/app/(app)/settings/git/_components/_modals/select-repositories-modal.tsx
+++ b/src/app/(app)/settings/git/_components/_modals/select-repositories-modal.tsx
@@ -91,6 +91,7 @@ export const SelectRepositoriesModal = (props: {
                 kodusConfigFileOverridesWebPreferences: true,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
             await createOrUpdateCodeReviewParameter(
                 defaultConfigs,

--- a/src/app/(app)/settings/integrations/azure-repos/@modal/configuration/page.tsx
+++ b/src/app/(app)/settings/integrations/azure-repos/@modal/configuration/page.tsx
@@ -111,6 +111,7 @@ export default function AzureRepos() {
                 kodusConfigFileOverridesWebPreferences: true,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
             await createOrUpdateCodeReviewParameter(
                 defaultConfigs,

--- a/src/app/(app)/settings/integrations/bitbucket/@modal/configuration/page.tsx
+++ b/src/app/(app)/settings/integrations/bitbucket/@modal/configuration/page.tsx
@@ -111,6 +111,7 @@ export default function Bitbucket() {
                 kodusConfigFileOverridesWebPreferences: true,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
             await createOrUpdateCodeReviewParameter(
                 defaultConfigs,

--- a/src/app/(app)/settings/integrations/github/@modal/configuration/page.tsx
+++ b/src/app/(app)/settings/integrations/github/@modal/configuration/page.tsx
@@ -111,6 +111,7 @@ export default function Github() {
                 kodusConfigFileOverridesWebPreferences: true,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
             await createOrUpdateCodeReviewParameter(
                 defaultConfigs,

--- a/src/app/(app)/settings/integrations/gitlab/@modal/configuration/page.tsx
+++ b/src/app/(app)/settings/integrations/gitlab/@modal/configuration/page.tsx
@@ -111,6 +111,7 @@ export default function Gitlab() {
                 kodusConfigFileOverridesWebPreferences: true,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
             await createOrUpdateCodeReviewParameter(
                 defaultConfigs,

--- a/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -95,6 +95,7 @@ export default function App() {
                 pullRequestApprovalActive: false,
                 isRequestChangesActive: false,
                 kodyRulesGeneratorEnabled: true,
+                runOnDraft: true,
             };
 
             await createOrUpdateCodeReviewParameter(

--- a/src/core/utils/helpers.ts
+++ b/src/core/utils/helpers.ts
@@ -225,6 +225,7 @@ export const codeReviewConfigRemovePropertiesNotInType = (
         "summary",
         "isRequestChangesActive",
         "kodyRulesGeneratorEnabled",
+        "runOnDraft",
     ];
 
     expectedKeys.forEach((key) => {


### PR DESCRIPTION
This pull request introduces a new setting for Kody's automated code review, allowing users to control whether reviews are performed on draft Pull Requests.

Key changes include:
*   **New 'Run on Draft Pull Requests' Setting:** A new boolean setting, `runOnDraft`, has been added to the code review configuration. When enabled, Kody will execute automated code reviews and provide feedback on Pull Requests even if they are in a draft state.
*   **User Interface:** A dedicated switch component has been integrated into the 'General' section of the code review settings page, enabling users to easily toggle this feature.
*   **Default Behavior:** The `runOnDraft` setting is now set to `true` by default for all new code review configurations, including those created during initial setup, repository selection, and integration with various Git platforms (GitHub, GitLab, Bitbucket, Azure Repos).
*   **Configuration Management:** The code review configuration types and utility functions have been updated to properly handle and persist the new `runOnDraft` property.