### PR TITLE
[fix] issues filters crashing when issues list is empty

### DIFF
--- a/src/app/(app)/issues/_components/filters.tsx
+++ b/src/app/(app)/issues/_components/filters.tsx
@@ -62,7 +62,7 @@ export const IssuesFilters = () => {
                     </div>
 
                     <div className="flex">
-                        {_localStorageFilters?.items.length && (
+                        {_localStorageFilters && (
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <ButtonWithFeedback

--- a/src/app/(app)/issues/_components/filters/group.tsx
+++ b/src/app/(app)/issues/_components/filters/group.tsx
@@ -153,7 +153,7 @@ export const FilterItemGroup = ({
                             ? false
                             : filters.items.some((f) => {
                                   if (isFilterValueGroup(f)) return false;
-                                  return f.value.trim().length === 0;
+                                  return f.value?.trim().length === 0;
                               })
                     }
                     onClick={() =>
@@ -183,7 +183,7 @@ export const FilterItemGroup = ({
                                 ? false
                                 : filters.items.some((f) => {
                                       if (isFilterValueGroup(f)) return false;
-                                      return f.value.trim().length === 0;
+                                      return f.value?.trim().length === 0;
                                   })
                         }
                         onClick={() =>


### PR DESCRIPTION
This pull request addresses issues related to the issues filter functionality, specifically preventing crashes and improving robustness when filter data is incomplete or empty.

Key changes include:
*   **Enhanced Filter UI Stability:** The "Clear all filters" button in the issues filter component will now correctly render based on the presence of filter data, even if the list of filter items is empty. This prevents potential UI issues or crashes when the filter state is initialized without any active filters.
*   **Prevented Crashes from Undefined Filter Values:** The application will no longer crash when attempting to evaluate filter values that are `null` or `undefined`. Optional chaining has been added to safely check for the existence of filter values before performing string operations, making the filter logic more resilient to incomplete or malformed filter data.