### PR TITLE
add new auto join config

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -56,8 +56,8 @@ export default async function Layout({ children }: React.PropsWithChildren) {
                 license={organizationLicense}
                 usersWithAssignedLicense={usersWithAssignedLicense}>
                 <SetupAndOnboardingLock />
-                <NavMenu 
-                    issuesPageFeatureFlag={issuesPageFeatureFlag} 
+                <NavMenu
+                    issuesPageFeatureFlag={issuesPageFeatureFlag}
                     logsPagesFeatureFlag={logsPagesFeatureFlag}
                 />
                 <FinishedTrialModal />

--- a/src/app/(auth)/components/register-page-content.tsx
+++ b/src/app/(auth)/components/register-page-content.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@components/ui/button";
+import { Card, CardContent, CardHeader } from "@components/ui/card";
+import { Checkbox } from "@components/ui/checkbox";
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleIndicator,
+    CollapsibleTrigger,
+} from "@components/ui/collapsible";
 import { FormControl } from "@components/ui/form-control";
 import { Heading } from "@components/ui/heading";
 import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
 import { Link } from "@components/ui/link";
 import { MultiStep, useMultiStep } from "@components/ui/multi-step";
+import { ScrollArea } from "@components/ui/scroll-area";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useDebouncedCallback } from "@hooks/use-debounced-callback";
 import {
@@ -26,7 +36,11 @@ import {
 } from "react-hook-form";
 import type { TODO } from "src/core/types";
 import { cn } from "src/core/utils/components";
-import { checkForEmailExistence, registerUser } from "src/lib/auth/fetchers";
+import {
+    checkForEmailExistence,
+    getOrganizationsByDomain,
+    registerUser,
+} from "src/lib/auth/fetchers";
 import { z } from "zod";
 
 import { OAuthButtons } from "./oauth";
@@ -45,6 +59,41 @@ const GetStarted = () => {
             shouldTouch: true,
         });
     });
+
+    const [isLoading, setIsLoading] = useState(false);
+
+    // TODO: investigate why using form.handleSubmit was not transitioning multi step pages or showing console.logs for some reason
+    const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        const isEmailValid = await form.trigger("email");
+        if (!isEmailValid) {
+            return;
+        }
+
+        setIsLoading(true);
+
+        const email = form.getValues("email");
+        const [, domain] = email.split("@");
+
+        try {
+            const matchedOrganizations = await getOrganizationsByDomain(domain);
+
+            if (matchedOrganizations.length > 0) {
+                form.setValue("foundOrganizations", matchedOrganizations);
+                multiStep.navigateTo("match-domain");
+            } else {
+                form.setValue("foundOrganizations", []);
+                multiStep.navigateTo("with-email");
+            }
+        } catch (error) {
+            console.error("Error fetching organizations:", error);
+            form.setValue("foundOrganizations", []);
+            multiStep.navigateTo("with-email");
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     return (
         <div className="flex flex-col gap-6">
@@ -69,10 +118,7 @@ const GetStarted = () => {
 
             <form
                 className="flex w-full flex-col gap-4"
-                onSubmit={(ev) => {
-                    ev.preventDefault();
-                    multiStep.navigateTo("with-email");
-                }}>
+                onSubmit={handleFormSubmit}>
                 <Controller
                     name="email"
                     control={form.control}
@@ -116,10 +162,135 @@ const GetStarted = () => {
                     variant="primary"
                     className="w-full"
                     rightIcon={<ArrowRight />}
-                    disabled={!isEmailFilled || isEmailInvalid}>
+                    disabled={!isEmailFilled || isEmailInvalid || isLoading}>
                     Continue
                 </Button>
             </form>
+        </div>
+    );
+};
+
+const MatchDomain = () => {
+    const multiStep = useMultiStep();
+    const form = useFormContext<z.infer<typeof formSchema>>();
+    const organizations = form.watch("foundOrganizations");
+
+    const [selectedOrganization, setSelectedOrganization] = useState<
+        string | undefined
+    >(undefined);
+
+    return (
+        <div className="flex flex-col gap-10">
+            <Button
+                size="sm"
+                variant="helper"
+                className="text-xs"
+                leftIcon={<ArrowLeft />}
+                onClick={() => multiStep.navigateTo("get-started")}>
+                Back to Sign Up
+            </Button>
+
+            <div className="flex flex-col gap-2">
+                <Heading variant="h2">We found some organizations!</Heading>
+
+                <p className="text-text-secondary text-sm">
+                    We found organizations associated with your email domain.
+                    Select one to join or create a new organization.
+                </p>
+            </div>
+
+            <div className="max-h-[30vh] w-full overflow-y-auto">
+                <div className="flex h-full w-full flex-col gap-2">
+                    {organizations.map((org) => (
+                        <Card key={org.uuid}>
+                            <Collapsible className="w-full">
+                                <CardHeader className="flex flex-row items-center gap-3 px-5 py-4">
+                                    <Checkbox
+                                        id={org.uuid}
+                                        className="flex-shrink-0 self-center"
+                                        checked={
+                                            selectedOrganization === org.uuid
+                                        }
+                                        onClick={() => {
+                                            setSelectedOrganization(
+                                                selectedOrganization ===
+                                                    org.uuid
+                                                    ? ""
+                                                    : org.uuid,
+                                            );
+                                        }}
+                                    />
+
+                                    <Label
+                                        htmlFor={org.uuid}
+                                        className="flex-1">
+                                        {org.name}
+                                    </Label>
+
+                                    <div className="flex items-center gap-3">
+                                        <CollapsibleTrigger asChild>
+                                            <Button
+                                                active
+                                                size="icon-sm"
+                                                variant="helper">
+                                                <CollapsibleIndicator />
+                                            </Button>
+                                        </CollapsibleTrigger>
+                                    </div>
+                                </CardHeader>
+
+                                <CollapsibleContent asChild className="pb-0">
+                                    <CardContent className="bg-card-lv1 flex flex-col gap-5 pt-4">
+                                        <p className="text-text-secondary text-sm">
+                                            Owner: {org.owner}
+                                        </p>
+                                    </CardContent>
+                                </CollapsibleContent>
+                            </Collapsible>
+                        </Card>
+                    ))}
+                </div>
+            </div>
+
+            <div className="flex flex-col gap-4">
+                <Button
+                    size="lg"
+                    variant="primary"
+                    className="w-full"
+                    rightIcon={<ArrowRight />}
+                    onClick={() => {
+                        if (selectedOrganization) {
+                            form.setValue(
+                                "selectedOrganization",
+                                selectedOrganization,
+                            );
+                        }
+                        multiStep.navigateTo("with-email");
+                    }}
+                    disabled={!selectedOrganization}>
+                    Continue
+                </Button>
+
+                <Button
+                    size="md"
+                    variant="secondary"
+                    className="w-full"
+                    onClick={() => {
+                        form.setValue("selectedOrganization", undefined);
+                        multiStep.navigateTo("with-email");
+                    }}>
+                    Create a new organization
+                </Button>
+                <div className="text-text-secondary text-center text-xs">
+                    If you don't see your organization,{" "}
+                    <Link
+                        target="_blank"
+                        href={process.env.WEB_SUPPORT_DISCORD_INVITE_URL ?? ""}>
+                        contact support
+                    </Link>
+                    .
+                </div>
+            </div>
         </div>
     );
 };
@@ -160,9 +331,16 @@ const WithEmail = () => {
 
     const onSubmit = form.handleSubmit(async (data) => {
         try {
-            const { name, password, email } = data;
+            const { name, password, email, selectedOrganization } = data;
 
-            await registerUser({ name, email, password });
+            console.log(data);
+
+            await registerUser({
+                name,
+                email,
+                password,
+                organizationId: selectedOrganization,
+            });
 
             await signIn("credentials", {
                 email,
@@ -182,6 +360,20 @@ const WithEmail = () => {
         }
     });
 
+    const foundOrganizations = form.watch("foundOrganizations");
+    const backButtonText =
+        foundOrganizations?.length > 0
+            ? "Back to Organization Selection"
+            : "Back to Sign Up";
+
+    const handleBack = () => {
+        if (foundOrganizations?.length > 0) {
+            multiStep.navigateTo("match-domain");
+        } else {
+            multiStep.navigateTo("get-started");
+        }
+    };
+
     return (
         <div className="flex flex-col gap-10">
             <Button
@@ -189,8 +381,8 @@ const WithEmail = () => {
                 variant="helper"
                 className="text-xs"
                 leftIcon={<ArrowLeft />}
-                onClick={() => multiStep.back()}>
-                Back to Sign Up
+                onClick={handleBack}>
+                {backButtonText}
             </Button>
 
             <div className="flex flex-col gap-2">
@@ -432,6 +624,14 @@ const formSchema = z
                     "Password must include at least 1 uppercase letter, 1 number, and 1 special character",
             }),
         confirmPassword: z.string({ required_error: "Confirm your password" }),
+        foundOrganizations: z.array(
+            z.object({
+                uuid: z.string(),
+                name: z.string(),
+                owner: z.string().optional(),
+            }),
+        ),
+        selectedOrganization: z.string().optional(),
     })
 
     .superRefine(({ confirmPassword, password }, ctx) => {
@@ -453,6 +653,8 @@ export const RegisterPageContent = () => {
             email: "",
             password: "",
             confirmPassword: "",
+            foundOrganizations: [],
+            selectedOrganization: "",
         },
     });
 
@@ -462,6 +664,7 @@ export const RegisterPageContent = () => {
                 initialStep="get-started"
                 steps={{
                     "get-started": GetStarted,
+                    "match-domain": MatchDomain,
                     "with-email": WithEmail,
                 }}
             />

--- a/src/core/config/constants.ts
+++ b/src/core/config/constants.ts
@@ -14,4 +14,5 @@ export enum API_ROUTES {
     segmentTrack = "/segment/track",
     loginOAuth = "/auth/oauth",
     checkForEmailExistence = "/user/email",
+    getOrganizationsByDomain = "/organization/domain",
 }

--- a/src/lib/auth/fetchers.ts
+++ b/src/lib/auth/fetchers.ts
@@ -23,6 +23,7 @@ export const registerUser = (payload: {
     name: string;
     email: string;
     password: string;
+    organizationId?: string;
 }): Promise<{
     data: {
         statusCode: number;
@@ -99,10 +100,32 @@ export const loginOAuth = (
     });
 };
 
-export const sendForgotPasswordMail =async (email:string)=>{
-    return axiosApi.post(pathToApiUrl(API_ROUTES.forgotPassword),{email})
-}
+export const sendForgotPasswordMail = async (email: string) => {
+    return axiosApi.post(pathToApiUrl(API_ROUTES.forgotPassword), { email });
+};
 
-export const resetPassword =async (newPassword:string,token:string)=>{
-    return axiosApi.post(pathToApiUrl(API_ROUTES.resetPassword),{newPassword,token})
-}
+export const resetPassword = async (newPassword: string, token: string) => {
+    return axiosApi.post(pathToApiUrl(API_ROUTES.resetPassword), {
+        newPassword,
+        token,
+    });
+};
+
+export const getOrganizationsByDomain = async (domain: string) => {
+    try {
+        const data = await typedFetch<
+            { uuid: string; name: string; owner?: string }[]
+        >(pathToApiUrl(API_ROUTES.getOrganizationsByDomain), {
+            params: { domain },
+            signedIn: false,
+        });
+        return data;
+    } catch (error) {
+        if (error instanceof Error) {
+            throw new Error(
+                `Failed to fetch organizations by domain: ${error.message}`,
+            );
+        }
+        throw error;
+    }
+};

--- a/src/lib/services/parameters/types.ts
+++ b/src/lib/services/parameters/types.ts
@@ -7,6 +7,7 @@ export enum ParametersConfigKey {
 
 export enum OrganizationParametersConfigKey {
     TIMEZONE_CONFIG = "timezone_config",
+    AUTO_JOIN_CONFIG = "auto_join_config",
 }
 
 export enum BoardPriorityType {
@@ -68,3 +69,8 @@ export enum Timezone {
     NEW_YORK = "America/New_York",
     SAO_PAULO = "America/Sao_Paulo",
 }
+
+export type OrganizationParametersAutoJoinConfig = {
+    enabled: boolean;
+    domains: string[];
+};


### PR DESCRIPTION
This pull request introduces an "Auto Join" feature for organizations, enhancing the user registration process and providing more control over organization membership.

Key changes include:

*   **Auto Join Configuration**: Organizations can now enable an "Auto Join" setting, allowing users with matching email domains to automatically join the organization. This setting is configurable during the initial workspace setup and can be managed later in the organization's general settings page. A validation ensures that only the user's own email domain can be added to the auto-join list.
*   **Enhanced User Registration Flow**: When a new user registers, the system will check if their email domain is associated with any existing organizations that have the "Auto Join" feature enabled.
    *   If matching organizations are found, the user is presented with a new step in the registration flow to select an organization to join or choose to create a new one.
    *   The registration form and associated components have been updated to support this new selection process.
*   **API and Data Model Updates**:
    *   A new API endpoint (`/organization/domain`) has been added to fetch organizations based on an email domain.
    *   The user registration service now supports an optional `organizationId` to facilitate direct joining of an existing organization.
    *   A new organization parameter (`AUTO_JOIN_CONFIG`) and its corresponding data type (`OrganizationParametersAutoJoinConfig`) have been introduced to store the auto-join settings, including its enabled status and a list of approved domains.