### PR TITLE
[feat] `kodus-ai` github stars visible on navbar

### DIFF
--- a/src/core/layout/navbar/_components/github-stars.tsx
+++ b/src/core/layout/navbar/_components/github-stars.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import { SvgGithub } from "@components/ui/icons/SvgGithub";
+import { Link } from "@components/ui/link";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { XIcon } from "lucide-react";
+import { cn } from "src/core/utils/components";
+
+const repository = "kodustech/kodus-ai";
+const repositoryUrl = `https://github.com/${repository}`;
+const localStorageKey = "hide-github-stars-on-navbar";
+
+export const GithubStars = () => {
+    const [visible, setVisible] = useState(
+        localStorage.getItem(localStorageKey) !== "true",
+    );
+
+    const data = useSuspenseQuery<{ stargazers_count: number }, Error>({
+        queryKey: ["github-project-repository-data"],
+        queryFn: async ({ signal }) => {
+            const response = await fetch(
+                `https://api.github.com/repos/${repository}`,
+                { signal },
+            );
+            return response.json();
+        },
+    });
+
+    if (!visible) return;
+
+    return (
+        <div className={cn("group relative flex gap-px")}>
+            <div className="absolute -top-2 -right-1 z-1 hidden group-hover:block">
+                <Button
+                    size="icon-xs"
+                    variant="tertiary"
+                    className="size-4 [--icon-size:calc(var(--spacing)*3)]"
+                    onClick={() => {
+                        localStorage.setItem(localStorageKey, "true");
+                        setVisible(false);
+                    }}>
+                    <XIcon />
+                </Button>
+            </div>
+
+            <Link target="_blank" href={repositoryUrl}>
+                <Button
+                    decorative
+                    size="sm"
+                    variant="helper"
+                    className="rounded-r-none"
+                    leftIcon={<SvgGithub />}>
+                    Star
+                </Button>
+            </Link>
+
+            <Link target="_blank" href={`${repositoryUrl}/stargazers`}>
+                <Button
+                    active
+                    decorative
+                    size="sm"
+                    variant="helper"
+                    className={cn(
+                        "button-focused:text-primary-light",
+                        "button-hover:text-primary-light",
+                        "rounded-l-none",
+                    )}>
+                    {data.data.stargazers_count}
+                </Button>
+            </Link>
+        </div>
+    );
+};

--- a/src/core/layout/navbar/index.tsx
+++ b/src/core/layout/navbar/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@components/ui/navigation-menu";
 import { Spinner } from "@components/ui/spinner";
 import { GaugeIcon, InfoIcon, SlidersHorizontalIcon } from "lucide-react";
+import { ErrorBoundary } from "react-error-boundary";
 import { UserNav } from "src/core/layout/navbar/_components/user-nav";
 import { useAuth } from "src/core/providers/auth.provider";
 import { cn } from "src/core/utils/components";
@@ -34,6 +35,11 @@ const NoSSRIssuesCount = dynamic(
     },
 );
 
+const NoSSRGithubStars = dynamic(
+    () => import("./_components/github-stars").then((f) => f.GithubStars),
+    { ssr: false },
+);
+
 export const NavMenu = ({
     issuesPageFeatureFlag,
     logsPagesFeatureFlag,
@@ -41,9 +47,7 @@ export const NavMenu = ({
     issuesPageFeatureFlag: Awaited<
         ReturnType<typeof getFeatureFlagWithPayload>
     >;
-    logsPagesFeatureFlag: Awaited<
-        ReturnType<typeof getFeatureFlagWithPayload>
-    >;
+    logsPagesFeatureFlag: Awaited<ReturnType<typeof getFeatureFlagWithPayload>>;
 }) => {
     const pathname = usePathname();
     const { isOwner, isTeamLeader } = useAuth();
@@ -93,7 +97,12 @@ export const NavMenu = ({
         }
 
         return items;
-    }, [isOwner, isTeamLeader, issuesPageFeatureFlag?.value, logsPagesFeatureFlag?.value]);
+    }, [
+        isOwner,
+        isTeamLeader,
+        issuesPageFeatureFlag?.value,
+        logsPagesFeatureFlag?.value,
+    ]);
 
     const isActive = (route: string) => pathname.startsWith(route);
 
@@ -134,9 +143,12 @@ export const NavMenu = ({
             </div>
 
             <div className="flex items-center gap-4">
+                <ErrorBoundary fallback={null}>
+                    <NoSSRGithubStars />
+                </ErrorBoundary>
+
                 <div className="flex items-center gap-2">
                     <SubscriptionBadge />
-
                     <SupportDropdown />
                 </div>
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new feature to display the GitHub star count for the `kodus-ai` repository directly on the application's navigation bar.

Key changes include:

*   **GitHub Stars Component:** A new component (`GithubStars`) has been added to fetch and display the current star count for the `kodustech/kodus-ai` GitHub repository.
*   **Interactive Display:** The component includes a "Star" button that links to the repository and a button displaying the star count, which links to the repository's stargazers page.
*   **User Preference:** Users can hide this display from the navigation bar, and their preference is saved locally to persist across sessions.
*   **Integration into Navbar:** The `GithubStars` component is dynamically loaded (client-side only) and integrated into the main navigation bar, appearing alongside the subscription badge and support dropdown. It is also wrapped in an error boundary for improved resilience.
<!-- kody-pr-summary:end -->