### PR TITLE
Fix pull request page scroll

### DIFF
--- a/src/app/(app)/pull-requests/_components/page.client.tsx
+++ b/src/app/(app)/pull-requests/_components/page.client.tsx
@@ -21,7 +21,7 @@ export function PullRequestsPageClient() {
     });
 
     return (
-        <Page.Root className="overflow-hidden pb-0">
+        <Page.Root className="pb-0">
             <Page.Header className="max-w-full">
                 <div className="flex items-center justify-between w-full">
                     <div className="flex items-center gap-5">


### PR DESCRIPTION
Remove `overflow-hidden` from the pull requests page to fix broken scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0cd11ea-d6b6-4369-9753-4854fa126901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0cd11ea-d6b6-4369-9753-4854fa126901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



---

<!-- kody-pr-summary:start -->
Removes the `overflow-hidden` CSS class from the root container of the pull requests page. This change allows the page content to scroll, addressing an issue where content exceeding the viewport height was not accessible.
<!-- kody-pr-summary:end -->