### PR TITLE
fixing filters

### DIFF
--- a/src/app/(app)/pull-requests/_components/repository-filter.tsx
+++ b/src/app/(app)/pull-requests/_components/repository-filter.tsx
@@ -29,11 +29,14 @@ export const RepositoryFilter = ({
     selectedRepository, 
     onRepositoryChange 
 }: Props) => {
-    const { data: repositories = [], isLoading } = useGetRepositories(
+    const { data: allRepositories = [], isLoading } = useGetRepositories(
         teamId,
         undefined,
-        { isSelected: true },
     );
+
+    // Filter only selected repositories in the frontend as a temporary fix
+    // TODO: Backend should handle isSelected filter properly
+    const repositories = allRepositories.filter((repo: any) => repo.selected);
 
     const [open, setOpen] = useState(false);
 

--- a/src/features/ee/cockpit/_components/repository-picker.tsx
+++ b/src/features/ee/cockpit/_components/repository-picker.tsx
@@ -28,11 +28,14 @@ type Props = {
 };
 
 export const RepositoryPicker = ({ cookieValue, teamId }: Props) => {
-    const { data: repositories = [], isLoading } = useGetRepositories(
+    const { data: allRepositories = [], isLoading } = useGetRepositories(
         teamId,
         undefined,
-        { isSelected: true },
     );
+
+    // Filter only selected repositories in the frontend as a temporary fix
+    // TODO: Backend should handle isSelected filter properly
+    const repositories = allRepositories.filter((repo: any) => repo.selected);
 
     const router = useRouter();
     const [loading, startTransition] = useTransition();

--- a/src/lib/services/codeManagement/types.ts
+++ b/src/lib/services/codeManagement/types.ts
@@ -20,6 +20,7 @@ export type Repository = {
         id?: string;
         name?: string;
     };
+    selected?: boolean;
 };
 
 export type GitFileOrFolder = {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses an issue with repository filtering by implementing a temporary client-side solution.

The changes include:
- **Client-side Filtering:** The `RepositoryFilter` and `RepositoryPicker` components now fetch all repositories and then filter them in the frontend to display only those marked as `selected`. This bypasses a previous attempt to filter using an `isSelected: true` parameter in the `useGetRepositories` hook, which was not functioning as expected.
- **Type Definition Update:** The `Repository` type definition has been updated to include an optional `selected?: boolean` property, supporting the new client-side filtering logic.

This ensures that only selected repositories are displayed in the UI until the backend properly supports the `isSelected` filter.
<!-- kody-pr-summary:end -->