### PR TITLE
Feate/new review engine

### DIFF
--- a/src/app/(app)/settings/_components/_layout.tsx
+++ b/src/app/(app)/settings/_components/_layout.tsx
@@ -38,6 +38,7 @@ import { PerRepository } from "./per-repository/repository";
 
 const routes = [
     { label: "General", href: "general" },
+    { label: "Review Categories", href: "review-categories" },
     { label: "Suggestion Control", href: "suggestion-control" },
     { label: "PR Summary", href: "pr-summary" },
     { label: "Kody Rules", href: "kody-rules" },

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
@@ -53,7 +53,7 @@ export const AnalysisTypes = () => {
             !allLabelsLoading &&
             !initializedRef.current
         ) {
-            const currentOptions = form.getValues("reviewOptions");
+            const currentOptions = form.getValues("reviewOptions") || {};
             const mergedOptions: Record<string, boolean> = {};
 
             // Add all categories from both versions with their current values or false as default

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
@@ -7,7 +7,7 @@ import { Heading } from "@components/ui/heading";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
 import { useGetCodeReviewLabels, useGetAllCodeReviewLabels } from "@services/parameters/hooks";
 import { Controller, useFormContext } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { CodeReviewFormType, CodeReviewOptions } from "../../../_types";
 
@@ -35,21 +35,29 @@ export const AnalysisTypes = () => {
     const codeReviewVersion = form.watch("codeReviewVersion") || "legacy";
     const { data: labels = [], isLoading } = useGetCodeReviewLabels(codeReviewVersion);
     const { v1, v2, isLoading: allLabelsLoading, allLabels } = useGetAllCodeReviewLabels();
+    const initializedRef = useRef(false);
     
     // Merge all categories ensuring boolean values - keep user's existing values
     useEffect(() => {
-        if (allLabels.length > 0) {
+        if (allLabels.length > 0 && !allLabelsLoading && !initializedRef.current) {
             const currentOptions = form.getValues("reviewOptions");
             const mergedOptions: Record<string, boolean> = {};
+            
+            console.log("🔄 AnalysisTypes: Initial merge - allLabels loaded:", allLabels.map(l => l.type));
+            console.log("🔄 AnalysisTypes: currentOptions:", currentOptions);
+            console.log("🔄 AnalysisTypes: v1 labels:", v1.data?.map(l => l.type));
+            console.log("🔄 AnalysisTypes: v2 labels:", v2.data?.map(l => l.type));
             
             // Add all categories from both versions with their current values or false as default
             allLabels.forEach(label => {
                 mergedOptions[label.type] = Boolean(currentOptions[label.type] ?? false);
             });
 
+            console.log("🔄 AnalysisTypes: mergedOptions:", mergedOptions);
             form.setValue("reviewOptions", mergedOptions);
+            initializedRef.current = true;
         }
-    }, [allLabels, form]);
+    }, [allLabels.length, allLabelsLoading]); // Only run once when labels are loaded
 
     const reviewOptionsOptions: CheckboxCardOption[] = labels.map(
         (label: any) => ({

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Button } from "@components/ui/button";
 import { Checkbox } from "@components/ui/checkbox";
 import { FormControl } from "@components/ui/form-control";
 import { Heading } from "@components/ui/heading";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
-import { useGetCodeReviewLabels, useGetAllCodeReviewLabels } from "@services/parameters/hooks";
+import {
+    useGetAllCodeReviewLabels,
+    useGetCodeReviewLabels,
+} from "@services/parameters/hooks";
 import { Controller, useFormContext } from "react-hook-form";
-import { useEffect, useRef } from "react";
 
 import type { CodeReviewFormType, CodeReviewOptions } from "../../../_types";
 
@@ -33,27 +36,33 @@ interface CheckboxCardOption {
 export const AnalysisTypes = () => {
     const form = useFormContext<CodeReviewFormType>();
     const codeReviewVersion = form.watch("codeReviewVersion") || "legacy";
-    const { data: labels = [], isLoading } = useGetCodeReviewLabels(codeReviewVersion);
-    const { v1, v2, isLoading: allLabelsLoading, allLabels } = useGetAllCodeReviewLabels();
+    const { data: labels = [], isLoading } =
+        useGetCodeReviewLabels(codeReviewVersion);
+    const {
+        v1,
+        v2,
+        isLoading: allLabelsLoading,
+        allLabels,
+    } = useGetAllCodeReviewLabels();
     const initializedRef = useRef(false);
-    
+
     // Merge all categories ensuring boolean values - keep user's existing values
     useEffect(() => {
-        if (allLabels.length > 0 && !allLabelsLoading && !initializedRef.current) {
+        if (
+            allLabels.length > 0 &&
+            !allLabelsLoading &&
+            !initializedRef.current
+        ) {
             const currentOptions = form.getValues("reviewOptions");
             const mergedOptions: Record<string, boolean> = {};
-            
-            console.log("🔄 AnalysisTypes: Initial merge - allLabels loaded:", allLabels.map(l => l.type));
-            console.log("🔄 AnalysisTypes: currentOptions:", currentOptions);
-            console.log("🔄 AnalysisTypes: v1 labels:", v1.data?.map(l => l.type));
-            console.log("🔄 AnalysisTypes: v2 labels:", v2.data?.map(l => l.type));
-            
+
             // Add all categories from both versions with their current values or false as default
-            allLabels.forEach(label => {
-                mergedOptions[label.type] = Boolean(currentOptions[label.type] ?? false);
+            allLabels.forEach((label) => {
+                mergedOptions[label.type] = Boolean(
+                    currentOptions[label.type] ?? false,
+                );
             });
 
-            console.log("🔄 AnalysisTypes: mergedOptions:", mergedOptions);
             form.setValue("reviewOptions", mergedOptions);
             initializedRef.current = true;
         }
@@ -81,7 +90,6 @@ export const AnalysisTypes = () => {
             control={form.control}
             render={({ field }) => (
                 <FormControl.Root className="@container space-y-1">
-
                     <FormControl.Input>
                         <ToggleGroup.Root
                             id={field.name}
@@ -89,26 +97,36 @@ export const AnalysisTypes = () => {
                             disabled={field.disabled}
                             className="grid auto-rows-fr grid-cols-1 gap-2 @lg:grid-cols-2 @3xl:grid-cols-3"
                             value={(() => {
-                                const validOptions = labels.map(label => label.type);
+                                const validOptions = labels.map(
+                                    (label) => label.type,
+                                );
                                 const mappedValues = mapReviewOptionsToValues(
                                     mapToReviewOptions(field.value),
                                 );
-                                
+
                                 return Object.entries(mappedValues)
-                                    .filter(([key, value]) => validOptions.includes(key) && value)
+                                    .filter(
+                                        ([key, value]) =>
+                                            validOptions.includes(key) && value,
+                                    )
                                     .map(([key]) => key);
                             })()}
                             onValueChange={(values) => {
                                 // Keep all existing categories from both versions, only update current version
-                                const currentOptions = form.getValues("reviewOptions") || {};
-                                const currentVersionOptions = labels.map(label => label.type);
+                                const currentOptions =
+                                    form.getValues("reviewOptions") || {};
+                                const currentVersionOptions = labels.map(
+                                    (label) => label.type,
+                                );
 
                                 // Start with all existing options
-                                const updatedOptions: Record<string, boolean> = { ...currentOptions };
-                                
+                                const updatedOptions: Record<string, boolean> =
+                                    { ...currentOptions };
+
                                 // Update only the current version's categories
-                                currentVersionOptions.forEach(option => {
-                                    updatedOptions[option] = values.includes(option);
+                                currentVersionOptions.forEach((option) => {
+                                    updatedOptions[option] =
+                                        values.includes(option);
                                 });
 
                                 field.onChange(updatedOptions);
@@ -138,7 +156,9 @@ export const AnalysisTypes = () => {
                                             <Checkbox
                                                 decorative
                                                 checked={
-                                                    field.value?.[option.value] || false
+                                                    field.value?.[
+                                                        option.value
+                                                    ] || false
                                                 }
                                             />
                                         </div>

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/analysis-types.tsx
@@ -5,63 +5,23 @@ import { Checkbox } from "@components/ui/checkbox";
 import { FormControl } from "@components/ui/form-control";
 import { Heading } from "@components/ui/heading";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
-import { useSuspenseGetCodeReviewLabels } from "@services/parameters/hooks";
+import { useGetCodeReviewLabels, useGetAllCodeReviewLabels } from "@services/parameters/hooks";
 import { Controller, useFormContext } from "react-hook-form";
+import { useEffect } from "react";
 
 import type { CodeReviewFormType, CodeReviewOptions } from "../../../_types";
 
-const labelTypeToKey: Record<string, keyof CodeReviewOptions> = {
-    performance_and_optimization: "performance_and_optimization",
-    security: "security",
-    error_handling: "error_handling",
-    refactoring: "refactoring",
-    maintainability: "maintainability",
-    potential_issues: "potential_issues",
-    code_style: "code_style",
-    documentation_and_comments: "documentation_and_comments",
-    kody_rules: "kody_rules",
-    breaking_changes: "breaking_changes",
-};
-
+// Dynamic mapping - no need for fixed keys anymore
 const mapReviewOptionsToValues = (
     reviewOptions: CodeReviewOptions,
 ): Record<string, boolean> => {
-    const values: Record<string, boolean> = {};
-    Object.keys(labelTypeToKey).forEach((key) => {
-        const optionKey = labelTypeToKey[key];
-        values[key] = reviewOptions[optionKey];
-    });
-
-    return values;
+    return { ...reviewOptions };
 };
 
 const mapToReviewOptions = (
     values: Record<string, boolean> = {},
 ): CodeReviewOptions => {
-    const options: Partial<CodeReviewOptions> = {};
-
-    Object.keys(values).forEach((key) => {
-        const mappedKey = labelTypeToKey[key];
-        if (mappedKey) {
-            options[mappedKey] = values[key];
-        } else {
-            console.warn(`Chave não mapeada: ${key}`);
-        }
-    });
-
-    return {
-        security: options.security || false,
-        code_style: options.code_style || false,
-        refactoring: options.refactoring || false,
-        error_handling: options.error_handling || false,
-        maintainability: options.maintainability || false,
-        potential_issues: options.potential_issues || false,
-        documentation_and_comments: options.documentation_and_comments || false,
-        performance_and_optimization:
-            options.performance_and_optimization || false,
-        kody_rules: options.kody_rules || false,
-        breaking_changes: options.breaking_changes || false,
-    };
+    return { ...values };
 };
 
 interface CheckboxCardOption {
@@ -72,7 +32,25 @@ interface CheckboxCardOption {
 
 export const AnalysisTypes = () => {
     const form = useFormContext<CodeReviewFormType>();
-    const labels = useSuspenseGetCodeReviewLabels();
+    const codeReviewVersion = form.watch("codeReviewVersion") || "legacy";
+    const { data: labels = [], isLoading } = useGetCodeReviewLabels(codeReviewVersion);
+    const { v1, v2, isLoading: allLabelsLoading, allLabels } = useGetAllCodeReviewLabels();
+    
+    // Merge all categories ensuring boolean values - keep user's existing values
+    useEffect(() => {
+        if (allLabels.length > 0) {
+            const currentOptions = form.getValues("reviewOptions");
+            const mergedOptions: Record<string, boolean> = {};
+            
+            // Add all categories from both versions with their current values or false as default
+            allLabels.forEach(label => {
+                mergedOptions[label.type] = Boolean(currentOptions[label.type] ?? false);
+            });
+
+            form.setValue("reviewOptions", mergedOptions);
+        }
+    }, [allLabels, form]);
+
     const reviewOptionsOptions: CheckboxCardOption[] = labels.map(
         (label: any) => ({
             value: label.type,
@@ -81,15 +59,20 @@ export const AnalysisTypes = () => {
         }),
     );
 
+    if (isLoading || allLabelsLoading) {
+        return (
+            <div className="flex items-center justify-center py-8">
+                <div className="text-text-secondary">Loading categories...</div>
+            </div>
+        );
+    }
+
     return (
         <Controller
             name="reviewOptions"
             control={form.control}
             render={({ field }) => (
                 <FormControl.Root className="@container space-y-1">
-                    <FormControl.Label htmlFor={field.name}>
-                        Analysis types
-                    </FormControl.Label>
 
                     <FormControl.Input>
                         <ToggleGroup.Root
@@ -97,29 +80,30 @@ export const AnalysisTypes = () => {
                             type="multiple"
                             disabled={field.disabled}
                             className="grid auto-rows-fr grid-cols-1 gap-2 @lg:grid-cols-2 @3xl:grid-cols-3"
-                            value={Object.entries(
-                                mapReviewOptionsToValues(
+                            value={(() => {
+                                const validOptions = labels.map(label => label.type);
+                                const mappedValues = mapReviewOptionsToValues(
                                     mapToReviewOptions(field.value),
-                                ),
-                            )
-                                .filter(([, value]) => value)
-                                .map(([key]) => key)}
+                                );
+                                
+                                return Object.entries(mappedValues)
+                                    .filter(([key, value]) => validOptions.includes(key) && value)
+                                    .map(([key]) => key);
+                            })()}
                             onValueChange={(values) => {
-                                const selectedOptions = mapToReviewOptions({
-                                    // get all options and set them to false
-                                    ...Object.fromEntries(
-                                        Object.keys(field.value ?? {}).map(
-                                            (value) => [value, false],
-                                        ),
-                                    ),
+                                // Keep all existing categories from both versions, only update current version
+                                const currentOptions = form.getValues("reviewOptions") || {};
+                                const currentVersionOptions = labels.map(label => label.type);
 
-                                    // then, set only selected options to true
-                                    ...Object.fromEntries(
-                                        values.map((value) => [value, true]),
-                                    ),
+                                // Start with all existing options
+                                const updatedOptions: Record<string, boolean> = { ...currentOptions };
+                                
+                                // Update only the current version's categories
+                                currentVersionOptions.forEach(option => {
+                                    updatedOptions[option] = values.includes(option);
                                 });
 
-                                field.onChange(selectedOptions);
+                                field.onChange(updatedOptions);
                             }}>
                             {reviewOptionsOptions.map((option) => (
                                 <ToggleGroup.ToggleGroupItem
@@ -146,9 +130,7 @@ export const AnalysisTypes = () => {
                                             <Checkbox
                                                 decorative
                                                 checked={
-                                                    field.value?.[
-                                                        option.value as keyof CodeReviewOptions
-                                                    ]
+                                                    field.value?.[option.value] || false
                                                 }
                                             />
                                         </div>

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/_components/code-review-version-selector.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/_components/code-review-version-selector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button } from "@components/ui/button";
+import { CardHeader } from "@components/ui/card";
+import { Heading } from "@components/ui/heading";
+import { Switch } from "@components/ui/switch";
+import { Controller, useFormContext } from "react-hook-form";
+
+import type { CodeReviewFormType } from "../../../_types";
+
+export const CodeReviewVersionSelector = () => {
+    const form = useFormContext<CodeReviewFormType>();
+
+    return (
+        <Controller
+            name="codeReviewVersion"
+            control={form.control}
+                    defaultValue="legacy"
+            render={({ field }) => (
+                <Button
+                    size="sm"
+                    variant="helper"
+                    onClick={() => field.onChange(field.value === "legacy" ? "v2" : "legacy")}
+                    className="w-full">
+                    <CardHeader className="flex flex-row items-center justify-between gap-6">
+                        <div className="flex flex-col gap-1">
+                            <Heading variant="h3">
+                                Enable New Review Engine
+                            </Heading>
+
+                            <p className="text-text-secondary text-sm">
+                                When enabled, reviews highlight only objective issues (bugs, security, performance, breaking changes, cross-file). Everything else is handled by Kody Rules, cutting noise and subjectivity.
+                            </p>
+                        </div>
+
+                        <Switch 
+                            decorative 
+                            checked={field.value === "v2"} 
+                        />
+                    </CardHeader>
+                </Button>
+            )}
+        />
+    );
+};

--- a/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
@@ -23,7 +23,6 @@ import GeneratingConfig from "../../_components/generating-config";
 import { type CodeReviewFormType } from "../../_types";
 import { usePlatformConfig } from "../../../_components/context";
 import { useCodeReviewRouteParams } from "../../../_hooks";
-import { AnalysisTypes } from "./_components/analysis-types";
 import { AutomatedReviewActive } from "./_components/automated-review-active";
 import { BaseBranches } from "./_components/base-branches";
 import { IgnorePaths } from "./_components/ignore-paths";
@@ -188,7 +187,6 @@ export default function General() {
                 <PullRequestApprovalActive />
                 <IsRequestChangesActive />
                 <RunOnDraft />
-                <AnalysisTypes />
                 <IgnorePaths />
                 <IgnoredTitleKeywords />
                 <BaseBranches />

--- a/src/app/(app)/settings/code-review/[repositoryId]/layout.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/layout.tsx
@@ -67,20 +67,15 @@ const getDefaultValues = (
             critical: config?.suggestionControl?.severityLimits?.critical ?? 0,
         },
     },
-    reviewOptions: {
-        code_style: config?.reviewOptions?.code_style ?? false,
-        documentation_and_comments:
-            config?.reviewOptions?.documentation_and_comments ?? false,
-        error_handling: config?.reviewOptions?.error_handling ?? false,
-        maintainability: config?.reviewOptions?.maintainability ?? false,
-        performance_and_optimization:
-            config?.reviewOptions?.performance_and_optimization ?? false,
-        potential_issues: config?.reviewOptions?.potential_issues ?? false,
-        refactoring: config?.reviewOptions?.refactoring ?? false,
-        security: config?.reviewOptions?.security ?? false,
-        kody_rules: config?.reviewOptions?.kody_rules ?? false,
-        breaking_changes: config?.reviewOptions?.breaking_changes ?? false,
-    },
+    reviewOptions: (() => {
+        const options = config?.reviewOptions ?? {};
+        const booleanOptions: Record<string, boolean> = {};
+        Object.entries(options).forEach(([key, value]) => {
+            booleanOptions[key] = Boolean(value);
+        });
+        return booleanOptions;
+    })(),
+    codeReviewVersion: config?.codeReviewVersion ?? "legacy",
     kodyRulesGeneratorEnabled: config?.kodyRulesGeneratorEnabled ?? true,
 });
 

--- a/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
@@ -32,16 +32,6 @@ export default function ReviewCategories() {
 
     const handleSubmit = form.handleSubmit(async (formData) => {
         try {
-            console.log("🔍 Form data being sent:", formData);
-            console.log("🔍 reviewOptions specifically:", formData.reviewOptions);
-            console.log("🔍 codeReviewVersion:", formData.codeReviewVersion);
-            console.log(
-                "🔍 reviewOptions types:",
-                Object.entries(formData.reviewOptions || {}).map(
-                    ([key, value]) => `${key}: ${typeof value} (${value})`,
-                ),
-            );
-            console.log("🔍 Total reviewOptions count:", Object.keys(formData.reviewOptions || {}).length);
 
             const result = await createOrUpdateCodeReviewParameter(
                 formData,

--- a/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Button } from "@components/ui/button";
+import { Heading } from "@components/ui/heading";
+import { Page } from "@components/ui/page";
+import { toast } from "@components/ui/toaster/use-toast";
+import { useReactQueryInvalidateQueries } from "@hooks/use-invalidate-queries";
+import { PARAMETERS_PATHS } from "@services/parameters";
+import { createOrUpdateCodeReviewParameter } from "@services/parameters/fetch";
+import {
+    KodyLearningStatus,
+    ParametersConfigKey,
+} from "@services/parameters/types";
+import { SaveIcon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import { useSelectedTeamId } from "src/core/providers/selected-team-context";
+
+import { CodeReviewPagesBreadcrumb } from "../../_components/breadcrumb";
+import GeneratingConfig from "../../_components/generating-config";
+import { type CodeReviewFormType } from "../../_types";
+import { usePlatformConfig } from "../../../_components/context";
+import { useCodeReviewRouteParams } from "../../../_hooks";
+import { AnalysisTypes } from "../general/_components/analysis-types";
+import { CodeReviewVersionSelector } from "../general/_components/code-review-version-selector";
+
+export default function ReviewCategories() {
+    const platformConfig = usePlatformConfig();
+    const form = useFormContext<CodeReviewFormType>();
+    const { teamId } = useSelectedTeamId();
+    const { repositoryId, directoryId } = useCodeReviewRouteParams();
+    const { resetQueries, generateQueryKey } = useReactQueryInvalidateQueries();
+
+    const handleSubmit = form.handleSubmit(async (formData) => {
+        try {
+            console.log("🔍 Form data being sent:", formData);
+            console.log(
+                "🔍 reviewOptions specifically:",
+                formData.reviewOptions,
+            );
+            console.log(
+                "🔍 reviewOptions types:",
+                Object.entries(formData.reviewOptions || {}).map(
+                    ([key, value]) => `${key}: ${typeof value} (${value})`,
+                ),
+            );
+
+            const result = await createOrUpdateCodeReviewParameter(
+                formData,
+                teamId,
+                repositoryId,
+                directoryId,
+            );
+
+            if (result.error) {
+                throw new Error(`Failed to save settings: ${result.error}`);
+            }
+
+            await resetQueries({
+                queryKey: generateQueryKey(PARAMETERS_PATHS.GET_BY_KEY, {
+                    params: {
+                        key: ParametersConfigKey.CODE_REVIEW_CONFIG,
+                        teamId,
+                    },
+                }),
+            });
+
+            form.reset(formData);
+
+            toast({
+                description: "Settings saved",
+                variant: "success",
+            });
+        } catch (error) {
+            console.error("Error saving settings:", error);
+
+            toast({
+                title: "Error",
+                description:
+                    "An error occurred while saving the settings. Please try again.",
+                variant: "danger",
+            });
+        }
+    });
+
+    const {
+        isDirty: formIsDirty,
+        isValid: formIsValid,
+        isSubmitting: formIsSubmitting,
+    } = form.formState;
+
+    if (
+        platformConfig.kodyLearningStatus ===
+        KodyLearningStatus.GENERATING_CONFIG
+    ) {
+        return <GeneratingConfig />;
+    }
+
+    return (
+        <Page.Root>
+            <Page.Header>
+                <CodeReviewPagesBreadcrumb pageName="Review Categories" />
+            </Page.Header>
+
+            <Page.Header>
+                <Page.Title>Review Categories</Page.Title>
+
+                <Page.HeaderActions>
+                    <Button
+                        size="md"
+                        variant="primary"
+                        leftIcon={<SaveIcon />}
+                        onClick={handleSubmit}
+                        disabled={!formIsDirty || !formIsValid}
+                        loading={formIsSubmitting}>
+                        Save settings
+                    </Button>
+                </Page.HeaderActions>
+            </Page.Header>
+
+            <Page.Content>
+                <CodeReviewVersionSelector />
+                <AnalysisTypes />
+            </Page.Content>
+        </Page.Root>
+    );
+}

--- a/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
+++ b/src/app/(app)/settings/code-review/[repositoryId]/review-categories/page.tsx
@@ -33,16 +33,15 @@ export default function ReviewCategories() {
     const handleSubmit = form.handleSubmit(async (formData) => {
         try {
             console.log("🔍 Form data being sent:", formData);
-            console.log(
-                "🔍 reviewOptions specifically:",
-                formData.reviewOptions,
-            );
+            console.log("🔍 reviewOptions specifically:", formData.reviewOptions);
+            console.log("🔍 codeReviewVersion:", formData.codeReviewVersion);
             console.log(
                 "🔍 reviewOptions types:",
                 Object.entries(formData.reviewOptions || {}).map(
                     ([key, value]) => `${key}: ${typeof value} (${value})`,
                 ),
             );
+            console.log("🔍 Total reviewOptions count:", Object.keys(formData.reviewOptions || {}).length);
 
             const result = await createOrUpdateCodeReviewParameter(
                 formData,

--- a/src/app/(app)/settings/code-review/_types.ts
+++ b/src/app/(app)/settings/code-review/_types.ts
@@ -48,19 +48,7 @@ export type CodeReviewFormType = CodeReviewGlobalConfig & {
     language: LanguageValue;
 };
 
-export type CodeReviewOptions = Record<
-    | "security"
-    | "code_style"
-    | "refactoring"
-    | "error_handling"
-    | "maintainability"
-    | "potential_issues"
-    | "documentation_and_comments"
-    | "performance_and_optimization"
-    | "kody_rules"
-    | "breaking_changes",
-    boolean
->;
+export type CodeReviewOptions = Record<string, boolean>;
 
 type SuggestionControlConfig = {
     groupingMode: GroupingModeSuggestions;
@@ -102,6 +90,7 @@ export type CodeReviewGlobalConfig = {
     isRequestChangesActive: boolean;
     kodyRulesGeneratorEnabled?: boolean;
     runOnDraft: boolean;
+    codeReviewVersion?: "legacy" | "v2";
 };
 
 type CodeReviewRepositoryConfigBase = CodeReviewGlobalConfig & {

--- a/src/core/utils/helpers.ts
+++ b/src/core/utils/helpers.ts
@@ -198,6 +198,9 @@ export const formatPeriodLabel = (period: string): string => {
 export const codeReviewConfigRemovePropertiesNotInType = (
     config: Partial<CodeReviewRepositoryConfig>,
 ) => {
+    console.log("🔧 Config before processing:", config);
+    console.log("🔧 reviewOptions before processing:", config.reviewOptions);
+    
     const newConfig: Partial<CodeReviewRepositoryConfig> = {};
     const expectedKeys: LiteralUnion<keyof CodeReviewRepositoryConfig>[] = [
         "id",
@@ -217,6 +220,7 @@ export const codeReviewConfigRemovePropertiesNotInType = (
         "isRequestChangesActive",
         "kodyRulesGeneratorEnabled",
         "runOnDraft",
+        "codeReviewVersion",
     ];
 
     expectedKeys.forEach((key) => {
@@ -226,6 +230,9 @@ export const codeReviewConfigRemovePropertiesNotInType = (
         ] as any;
     });
 
+    console.log("🔧 Config after processing:", newConfig);
+    console.log("🔧 reviewOptions after processing:", newConfig.reviewOptions);
+    
     return newConfig;
 };
 

--- a/src/core/utils/helpers.ts
+++ b/src/core/utils/helpers.ts
@@ -198,9 +198,6 @@ export const formatPeriodLabel = (period: string): string => {
 export const codeReviewConfigRemovePropertiesNotInType = (
     config: Partial<CodeReviewRepositoryConfig>,
 ) => {
-    console.log("🔧 Config before processing:", config);
-    console.log("🔧 reviewOptions before processing:", config.reviewOptions);
-    
     const newConfig: Partial<CodeReviewRepositoryConfig> = {};
     const expectedKeys: LiteralUnion<keyof CodeReviewRepositoryConfig>[] = [
         "id",
@@ -230,9 +227,6 @@ export const codeReviewConfigRemovePropertiesNotInType = (
         ] as any;
     });
 
-    console.log("🔧 Config after processing:", newConfig);
-    console.log("🔧 reviewOptions after processing:", newConfig.reviewOptions);
-    
     return newConfig;
 };
 

--- a/src/lib/services/parameters/hooks.ts
+++ b/src/lib/services/parameters/hooks.ts
@@ -101,11 +101,19 @@ export const useGetAllCodeReviewLabels = () => {
         }>
     >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS, { params: { codeReviewVersion: "v2" } }, true);
 
+    // Remove duplicates based on type
+    const uniqueLabels = new Map();
+    [...(v1Labels.data || []), ...(v2Labels.data || [])].forEach(label => {
+        if (!uniqueLabels.has(label.type)) {
+            uniqueLabels.set(label.type, label);
+        }
+    });
+
     return {
         v1: v1Labels,
         v2: v2Labels,
         isLoading: v1Labels.isLoading || v2Labels.isLoading,
-        allLabels: [...(v1Labels.data || []), ...(v2Labels.data || [])]
+        allLabels: Array.from(uniqueLabels.values())
     };
 };
 

--- a/src/lib/services/parameters/hooks.ts
+++ b/src/lib/services/parameters/hooks.ts
@@ -1,7 +1,7 @@
 import { UseMutationResult } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import type { AutomationCodeReviewConfigType } from "src/app/(app)/settings/code-review/_types";
-import { usePost, useSuspenseFetch } from "src/core/utils/reactQuery";
+import { useFetch, usePost, useSuspenseFetch } from "src/core/utils/reactQuery";
 
 import { PARAMETERS_PATHS } from ".";
 import { ParametersConfigKey, PlatformConfigValue } from "./types";
@@ -54,14 +54,59 @@ export const useSuspenseGetCodeReviewParameter = (teamId: string) => {
     );
 };
 
-export const useSuspenseGetCodeReviewLabels = () => {
+export const useSuspenseGetCodeReviewLabels = (codeReviewVersion?: string) => {
+    // Always send the parameter, even for legacy to be explicit
+    const params = { codeReviewVersion: codeReviewVersion || "legacy" };
+    
     return useSuspenseFetch<
         Array<{
             type: string;
             name: string;
             description: string;
         }>
-    >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS);
+    >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS, {
+        params
+    });
+};
+
+export const useGetCodeReviewLabels = (codeReviewVersion?: string) => {
+    // Always send the parameter, even for legacy to be explicit
+    const params = { 
+        params: { codeReviewVersion: codeReviewVersion || "legacy" }
+    };
+    
+    return useFetch<
+        Array<{
+            type: string;
+            name: string;
+            description: string;
+        }>
+    >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS, params, true);
+};
+
+export const useGetAllCodeReviewLabels = () => {
+    const v1Labels = useFetch<
+        Array<{
+            type: string;
+            name: string;
+            description: string;
+        }>
+    >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS, { params: { codeReviewVersion: "legacy" } }, true);
+    
+    const v2Labels = useFetch<
+        Array<{
+            type: string;
+            name: string;
+            description: string;
+        }>
+    >(PARAMETERS_PATHS.GET_CODE_REVIEW_LABELS, { params: { codeReviewVersion: "v2" } }, true);
+
+    return {
+        v1: v1Labels,
+        v2: v2Labels,
+        isLoading: v1Labels.isLoading || v2Labels.isLoading,
+        allLabels: [...(v1Labels.data || []), ...(v2Labels.data || [])]
+    };
 };
 
 export const useSuspenseGetParameterByKey = <T>(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a "New Review Engine" (v2) and a dedicated section for managing its settings.

Key changes include:

*   **New Review Engine Selection**: A new setting allows users to switch between the "legacy" code review engine and a "New Review Engine" (v2). The v2 engine is described as focusing on objective issues (e.g., bugs, security, performance, breaking changes, cross-file) to reduce subjectivity.
*   **Dedicated "Review Categories" Settings Page**: A new navigation item and page, "Review Categories," has been added to the settings. This page now houses the selector for the review engine version and the associated analysis types.
*   **Dynamic Analysis Types**: The selection of "Analysis types" (review categories) is no longer a fixed list. Categories are dynamically fetched and displayed based on the currently selected review engine version (legacy or v2). The system now supports and preserves the state of all possible categories across both engine versions.
*   **Configuration Updates**: The underlying data structure for code review options has been updated to support dynamic categories, and a `codeReviewVersion` field has been added to the configuration.
<!-- kody-pr-summary:end -->