### PR TITLE
[fix] github selfhosted collapsible in setup throwing error on any interaction

### DIFF
--- a/src/app/(setup)/setup/connecting-git-tool/_components/modals/gitlab.tsx
+++ b/src/app/(setup)/setup/connecting-git-tool/_components/modals/gitlab.tsx
@@ -135,19 +135,23 @@ export const GitlabTokenModal = (props: { teamId: string; userId: string }) => {
                             open={selfhosted}
                             onOpenChange={(s) => setSelfhosted(s)}
                             className="flex flex-col gap-1">
-                            <CollapsibleTrigger asChild>
-                                <Button
-                                    type="button"
-                                    variant="helper"
-                                    size="lg"
-                                    className="w-full items-center justify-between py-4">
-                                    <FormControl.Label className="mb-0">
-                                        Self-hosted
-                                    </FormControl.Label>
+                            <div className="relative">
+                                <CollapsibleTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="helper"
+                                        size="lg"
+                                        className="w-full items-center justify-between py-4">
+                                        <FormControl.Label className="mb-0">
+                                            Self-hosted
+                                        </FormControl.Label>
+                                    </Button>
+                                </CollapsibleTrigger>
 
+                                <div className="absolute inset-y-0 right-6 flex items-center">
                                     <Switch decorative checked={selfhosted} />
-                                </Button>
-                            </CollapsibleTrigger>
+                                </div>
+                            </div>
 
                             <CollapsibleContent>
                                 <Card color="lv1">


### PR DESCRIPTION
Similar issue: https://github.com/radix-ui/primitives/issues/3664
It's a temporary fix.

---

<!-- kody-pr-summary:start -->
Refactors the "Self-hosted" collapsible trigger within the GitLab connection setup modal. Previously, the `Switch` component was directly nested inside the `CollapsibleTrigger`'s button, which caused an error or unexpected behavior upon interaction. This change repositions the `Switch` component using absolute positioning, separating its interactive area from the `CollapsibleTrigger`'s click handler to ensure the collapsible functions correctly.
<!-- kody-pr-summary:end -->