### PR TITLE
add teamId to permission repo

### DIFF
--- a/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
+++ b/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
@@ -56,7 +56,7 @@ export default function AssignReposModal({ userId }: { userId: string }) {
     ] = useAsyncAction(async () => {
         const selectedIds = selectedRepositories.map((r) => r.id);
 
-        await assignRepos(selectedIds, userId);
+        await assignRepos(selectedIds, userId, teamId);
 
         magicModal.hide();
     });

--- a/src/lib/services/permissions/fetch.ts
+++ b/src/lib/services/permissions/fetch.ts
@@ -32,10 +32,14 @@ export const getAssignedRepos = async (userId: string) => {
     return response;
 };
 
-export const assignRepos = async (repositoryIds: string[], userId: string) => {
+export const assignRepos = async (
+    repositoryIds: string[],
+    userId: string,
+    teamId: string,
+) => {
     const reponse = await axiosAuthorized.post<string[]>(
         PERMISSIONS_PATHS.ASSIGN_REPOS,
-        { repositoryIds, userId },
+        { repositoryIds, userId, teamId },
     );
 
     return reponse;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
The `assignRepos` function has been updated to include `teamId` as a required parameter. This `teamId` is now passed in the request body when assigning repositories, allowing repository assignments to be associated with a specific team.
<!-- kody-pr-summary:end -->